### PR TITLE
chore: remove sdk_test pkg, centralize SaveConfiguration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,4 @@ linters:
     - govet           # Report suspicious constructs
 
 output:
-  formats:
-    - format: github-actions
-      path: stdout
   show-stats: true

--- a/internal/resources/port_settings/resource.go
+++ b/internal/resources/port_settings/resource.go
@@ -81,14 +81,6 @@ func (r *portSettingResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	// Save the configuration if autosave is enabled
-	if r.client.Autosave {
-		if err := r.client.SaveConfiguration(); err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save HRUI configuration, got error: %s", err))
-			return
-		}
-	}
-
 	// Set the ID
 	plan.ID = types.StringValue(strconv.FormatInt(plan.PortID.ValueInt64(), 10))
 
@@ -155,14 +147,6 @@ func (r *portSettingResource) Update(ctx context.Context, req resource.UpdateReq
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create HRUI port settings, got error: %s", err))
 		return
-	}
-
-	// Save the configuration if autosave is enabled
-	if r.client.Autosave {
-		if err := r.client.SaveConfiguration(); err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save HRUI configuration, got error: %s", err))
-			return
-		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/resources/qos_port_queue/resource.go
+++ b/internal/resources/qos_port_queue/resource.go
@@ -92,14 +92,6 @@ func (r *qosPortQueueResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	if r.client.Autosave {
-		err = r.client.SaveConfiguration()
-		if err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save configuration: %s", err))
-			return
-		}
-	}
-
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -122,14 +114,6 @@ func (r *qosPortQueueResource) Update(ctx context.Context, req resource.UpdateRe
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update QoS Port Queue: %s", err))
 		return
-	}
-
-	if r.client.Autosave {
-		err = r.client.SaveConfiguration()
-		if err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save configuration: %s", err))
-			return
-		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -178,14 +162,6 @@ func (r *qosPortQueueResource) Delete(ctx context.Context, req resource.DeleteRe
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reset QoS Port Queue for port %d: %s", portID, err))
 		return
-	}
-
-	if r.client.Autosave {
-		err = r.client.SaveConfiguration()
-		if err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save configuration: %s", err))
-			return
-		}
 	}
 
 	resp.State.RemoveResource(ctx)

--- a/internal/resources/qos_queue_weight/resource.go
+++ b/internal/resources/qos_queue_weight/resource.go
@@ -113,14 +113,6 @@ func (r *qosQueueWeightResource) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	if r.client.Autosave {
-		err = r.client.SaveConfiguration()
-		if err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save configuration: %s", err))
-			return
-		}
-	}
-
 	// Set the new state of the resource in Terraform
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -193,14 +185,6 @@ func (r *qosQueueWeightResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	if r.client.Autosave {
-		err = r.client.SaveConfiguration()
-		if err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save configuration: %s", err))
-			return
-		}
-	}
-
 	// Persist the latest state to Terraform
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
@@ -223,14 +207,6 @@ func (r *qosQueueWeightResource) Delete(ctx context.Context, req resource.Delete
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to reset QoS Queue Weight: %s", err))
 		return
-	}
-
-	if r.client.Autosave {
-		err = r.client.SaveConfiguration()
-		if err != nil {
-			resp.Diagnostics.AddError("Save Error", fmt.Sprintf("Unable to save configuration: %s", err))
-			return
-		}
 	}
 
 	// Remove resource from state

--- a/internal/sdk/igmp.go
+++ b/internal/sdk/igmp.go
@@ -32,9 +32,6 @@ func (c *HRUIClient) UpdateIGMPSnooping(enable bool) error {
 		return fmt.Errorf("failed to update global IGMP snooping: %w", err)
 	}
 
-	if c.Autosave {
-		return c.SaveConfiguration()
-	}
 	return nil
 }
 
@@ -89,9 +86,6 @@ func (c *HRUIClient) UpdatePortIGMPSnooping(port int, enable bool) error {
 		return fmt.Errorf("failed to update IGMP snooping for port %d: %w", port, err)
 	}
 
-	if c.Autosave {
-		return c.SaveConfiguration()
-	}
 	return nil
 }
 

--- a/internal/sdk/igmp_test.go
+++ b/internal/sdk/igmp_test.go
@@ -1,4 +1,4 @@
-package sdk_test
+package sdk
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/brennoo/terraform-provider-hrui/internal/sdk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -89,15 +88,6 @@ func mockIGMPHTMLStaticPorts(enabledPorts []int) string {
 	return html
 }
 
-func contains(s []int, e int) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 func TestGetPortIGMPSnooping(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -162,7 +152,7 @@ func TestGetPortIGMPSnooping(t *testing.T) {
 			defer server.Close()
 
 			// Create the mock client
-			client := &sdk.HRUIClient{
+			client := &HRUIClient{
 				URL:        server.URL,
 				HttpClient: server.Client(),
 			}

--- a/internal/sdk/ip.go
+++ b/internal/sdk/ip.go
@@ -76,9 +76,5 @@ func (c *HRUIClient) UpdateIPAddressSettings(settings *IPAddressSettings) error 
 		return fmt.Errorf("failed to update IP Settings: %w", err)
 	}
 
-	if c.Autosave {
-		return c.SaveConfiguration()
-	}
-
 	return nil
 }

--- a/internal/sdk/loop_test.go
+++ b/internal/sdk/loop_test.go
@@ -1,10 +1,9 @@
-package sdk_test
+package sdk
 
 import (
 	"net/http"
 	"testing"
 
-	"github.com/brennoo/terraform-provider-hrui/internal/sdk"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +37,7 @@ func TestGetLoopProtocol(t *testing.T) {
 	mockServer := mockServerMock(htmlResponse, http.StatusOK)
 	defer mockServer.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mockServer.URL,
 		HttpClient: &http.Client{},
 	}
@@ -55,7 +54,7 @@ func TestGetLoopProtocol(t *testing.T) {
 	assert.Equal(t, 10, loopProtocol.RecoverTime)
 
 	// Expected port statuses for each port (based on the HTML response)
-	expected := []sdk.PortStatus{
+	expected := []PortStatus{
 		{Port: 1, Enable: false, LoopState: "Disable", LoopStatus: "Forwarding"},
 		{Port: 2, Enable: true, LoopState: "Enable", LoopStatus: "Forwarding"},
 	}
@@ -70,13 +69,13 @@ func TestUpdateLoopProtocol(t *testing.T) {
 	defer mock.Close()
 
 	// Create an HRUIClient pointing to the mock server
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
 
 	// Call UpdateLoopProtocol and assert that no error is returned.
-	err := client.UpdateLoopProtocol("Loop Prevention", 5, 12, []sdk.PortStatus{
+	err := client.UpdateLoopProtocol("Loop Prevention", 5, 12, []PortStatus{
 		{Port: 1, Enable: true},
 		{Port: 2, Enable: false},
 	})
@@ -170,7 +169,7 @@ func TestGetSTPPortSettings(t *testing.T) {
 	defer mockServer.Close()
 
 	// Create a client instance
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mockServer.URL,
 		HttpClient: &http.Client{},
 	}
@@ -180,7 +179,7 @@ func TestGetSTPPortSettings(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Expected result based on the mock HTML structure
-	expected := []sdk.STPPort{
+	expected := []STPPort{
 		{
 			Port:           0,
 			State:          "Forwarding",
@@ -264,7 +263,7 @@ func TestGetLoopProtocol_LoopPreventionMode(t *testing.T) {
 	mockServer := mockServerMock(htmlResponse, http.StatusOK)
 	defer mockServer.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mockServer.URL,
 		HttpClient: &http.Client{},
 	}
@@ -276,7 +275,7 @@ func TestGetLoopProtocol_LoopPreventionMode(t *testing.T) {
 	assert.Equal(t, 5, loopProtocol.IntervalTime)
 	assert.Equal(t, 10, loopProtocol.RecoverTime)
 
-	expected := []sdk.PortStatus{
+	expected := []PortStatus{
 		{Port: 1, Enable: false, LoopState: "Disable", LoopStatus: "Forwarding"},
 		{Port: 2, Enable: true, LoopState: "Enable", LoopStatus: "Forwarding"},
 	}
@@ -288,7 +287,7 @@ func TestUpdateSTPPortSettings(t *testing.T) {
 	mock := mockServerMock("OK", http.StatusOK)
 	defer mock.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
@@ -346,7 +345,7 @@ func TestGetSTPSettings(t *testing.T) {
 	defer mockServer.Close()
 
 	// Create the HRUIClient with the mocked server URL.
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mockServer.URL,
 		HttpClient: &http.Client{},
 	}
@@ -377,13 +376,13 @@ func TestUpdateSTPSettings(t *testing.T) {
 	mock := mockServerMock("OK", http.StatusOK)
 	defer mock.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
 
 	// Create the STPGlobalSettings that we want to update.
-	stpUpdate := &sdk.STPGlobalSettings{
+	stpUpdate := &STPGlobalSettings{
 		ForceVersion: "RSTP", // Should map to version=1
 		Priority:     4096,
 		MaxAge:       15,

--- a/internal/sdk/mac_test.go
+++ b/internal/sdk/mac_test.go
@@ -1,12 +1,10 @@
-package sdk_test
+package sdk
 
 import (
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/brennoo/terraform-provider-hrui/internal/sdk"
 )
 
 func TestGetMACAddressTable(t *testing.T) {
@@ -59,7 +57,7 @@ func TestGetMACAddressTable(t *testing.T) {
 	defer mock.Close()
 
 	// Create an HRUIClient pointing to the mock server
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
@@ -68,7 +66,7 @@ func TestGetMACAddressTable(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Validate results with anonymized expected MAC addresses
-	expected := []sdk.MACAddressEntry{
+	expected := []MACAddressEntry{
 		{ID: 1, MAC: "AA:BB:CC:DD:EE:FF", VLANID: 1, Type: "dynamic", Port: 1},
 		{ID: 2, MAC: "11:22:33:44:55:66", VLANID: 1, Type: "dynamic", Port: 1},
 		{ID: 3, MAC: "77:88:99:AA:BB:CC", VLANID: 1, Type: "dynamic", Port: 1},
@@ -108,7 +106,7 @@ func TestGetStaticMACAddressTable(t *testing.T) {
 	defer mock.Close()
 
 	// Create client pointing to the mock server
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
@@ -119,7 +117,7 @@ func TestGetStaticMACAddressTable(t *testing.T) {
 	assert.Len(t, entries, 1)
 
 	// Validate the parsed entry
-	expectedEntry := sdk.StaticMACEntry{
+	expectedEntry := StaticMACEntry{
 		ID:         1,
 		MACAddress: "A8:80:55:59:E9:72",
 		VLANID:     1,
@@ -134,7 +132,7 @@ func TestAddStaticMACAddress(t *testing.T) {
 	defer mock.Close()
 
 	// Create client pointing to the mock server
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
@@ -150,13 +148,13 @@ func TestDeleteStaticMACAddress(t *testing.T) {
 	defer mock.Close()
 
 	// Create client pointing to the mock server
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        mock.URL,
 		HttpClient: &http.Client{},
 	}
 
 	// Test `DeleteStaticMACAddress` with two entries
-	entries := []sdk.StaticMACEntry{
+	entries := []StaticMACEntry{
 		{MACAddress: "01:23:45:67:89:AB", VLANID: 10},
 		{MACAddress: "02:33:44:55:66:77", VLANID: 20},
 	}

--- a/internal/sdk/port.go
+++ b/internal/sdk/port.go
@@ -155,10 +155,6 @@ func (c *HRUIClient) UpdatePortSettings(port *Port) error {
 		return fmt.Errorf("failed to update port settings: %w", err)
 	}
 
-	if c.Autosave {
-		return c.SaveConfiguration()
-	}
-
 	return nil
 }
 

--- a/internal/sdk/port_test.go
+++ b/internal/sdk/port_test.go
@@ -1,11 +1,10 @@
-package sdk_test
+package sdk
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/brennoo/terraform-provider-hrui/internal/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -103,7 +102,7 @@ func TestGetAllPorts(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        server.URL,
 		HttpClient: server.Client(),
 	}
@@ -112,7 +111,7 @@ func TestGetAllPorts(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, ports, 6)
 
-	expectedPorts := []*sdk.Port{
+	expectedPorts := []*Port{
 		{ID: 1, State: 1, SpeedDuplex: "Auto", FlowControl: "Off"},
 		{ID: 2, State: 1, SpeedDuplex: "Auto", FlowControl: "Off"},
 		{ID: 3, State: 1, SpeedDuplex: "Auto", FlowControl: "Off"},
@@ -131,7 +130,7 @@ func TestGetPort(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        server.URL,
 		HttpClient: server.Client(),
 	}
@@ -139,7 +138,7 @@ func TestGetPort(t *testing.T) {
 	port, err := client.GetPort(1)
 	require.NoError(t, err)
 
-	expectedPort := &sdk.Port{
+	expectedPort := &Port{
 		ID:          1,
 		State:       1,
 		SpeedDuplex: "Auto",
@@ -200,7 +199,7 @@ func TestGetPortStatistics(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &sdk.HRUIClient{
+	client := &HRUIClient{
 		URL:        server.URL,
 		HttpClient: server.Client(),
 	}
@@ -208,7 +207,7 @@ func TestGetPortStatistics(t *testing.T) {
 	stats, err := client.GetPortStatistics()
 	require.NoError(t, err)
 
-	expectedStats := []*sdk.PortStatistics{
+	expectedStats := []*PortStatistics{
 		{Port: 1, State: 1, LinkStatus: "Link Up", TxGoodPkt: 1539909, TxBadPkt: 0, RxGoodPkt: 6063265, RxBadPkt: 0},
 		{Port: 2, State: 1, LinkStatus: "Link Down", TxGoodPkt: 173978, TxBadPkt: 0, RxGoodPkt: 2140448, RxBadPkt: 0},
 	}

--- a/internal/sdk/test_helpers.go
+++ b/internal/sdk/test_helpers.go
@@ -1,4 +1,4 @@
-package sdk_test
+package sdk
 
 import (
 	"net/http"

--- a/internal/sdk/vlan.go
+++ b/internal/sdk/vlan.go
@@ -52,10 +52,6 @@ func (c *HRUIClient) CreateVLAN(vlan *Vlan, totalPorts int) error {
 		return fmt.Errorf("failed to create/update VLAN: %w", err)
 	}
 
-	if c.Autosave {
-		return c.SaveConfiguration()
-	}
-
 	return nil
 }
 
@@ -156,10 +152,6 @@ func (c *HRUIClient) DeleteVLAN(vlanID int) error {
 		return fmt.Errorf("failed to delete VLAN: %w", err)
 	}
 
-	if c.Autosave {
-		return c.SaveConfiguration()
-	}
-
 	return nil
 }
 
@@ -258,10 +250,6 @@ func (c *HRUIClient) SetPortVLANConfig(config *PortVLANConfig) error {
 	_, err := c.ExecuteFormRequest(portVLANURL, form)
 	if err != nil {
 		return fmt.Errorf("failed to set port VLAN config: %w", err)
-	}
-
-	if c.Autosave {
-		return c.SaveConfiguration()
 	}
 
 	return nil

--- a/internal/sdk/vlan_test.go
+++ b/internal/sdk/vlan_test.go
@@ -1,11 +1,10 @@
-package sdk_test
+package sdk
 
 import (
 	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/brennoo/terraform-provider-hrui/internal/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,7 +73,7 @@ func TestGetVLAN(t *testing.T) {
 	server := mockServerMock(htmlResponse, http.StatusOK)
 	defer server.Close()
 
-	client, err := sdk.NewClient(server.URL, "testuser", "testpass", false)
+	client, err := NewClient(server.URL, "testuser", "testpass", false)
 	require.NoError(t, err)
 	require.NotNil(t, client, "Client should not be nil")
 
@@ -99,10 +98,10 @@ func TestCreateVLAN_NotMemberPorts(t *testing.T) {
 	server := mockServerMock("", http.StatusOK)
 	defer server.Close()
 
-	client, _ := sdk.NewClient(server.URL, "testuser", "testpass", false)
+	client, _ := NewClient(server.URL, "testuser", "testpass", false)
 	totalPorts := 6
 
-	vlan := &sdk.Vlan{
+	vlan := &Vlan{
 		VlanID:        10,
 		Name:          "VLAN-Test",
 		UntaggedPorts: []int{1, 2}, // Members
@@ -120,7 +119,7 @@ func TestDeleteVLAN(t *testing.T) {
 	defer server.Close()
 
 	// Create an HRUIClient and point it to the mock server URL
-	client, _ := sdk.NewClient(server.URL, "testuser", "testpass", false)
+	client, _ := NewClient(server.URL, "testuser", "testpass", false)
 
 	// Test that deleting the VLAN sends the correct form submission
 	err := client.DeleteVLAN(10)
@@ -190,7 +189,7 @@ func TestGetAllVLANs(t *testing.T) {
 	server := mockServerMock(htmlResponse, http.StatusOK)
 	defer server.Close()
 
-	client, _ := sdk.NewClient(server.URL, "testuser", "testpass", false)
+	client, _ := NewClient(server.URL, "testuser", "testpass", false)
 
 	vlans, err := client.GetAllVLANs()
 	assert.NoError(t, err)
@@ -205,7 +204,7 @@ func TestGetAllVLANs(t *testing.T) {
 
 	assert.Equal(t, 4, len(vlans))
 
-	expectedVLANs := []*sdk.Vlan{
+	expectedVLANs := []*Vlan{
 		{VlanID: 1, Name: "", MemberPorts: []int{1, 2, 3, 4, 5, 6}, TaggedPorts: []int{}, UntaggedPorts: []int{1, 2, 3, 4, 5, 6}},
 		{VlanID: 4, Name: "vier", MemberPorts: []int{6}, TaggedPorts: []int{}, UntaggedPorts: []int{6}},
 		{VlanID: 5, Name: "funf", MemberPorts: []int{5}, TaggedPorts: []int{}, UntaggedPorts: []int{5}},
@@ -264,7 +263,7 @@ func TestGetAllPortVLANConfigs(t *testing.T) {
 	server := mockServerMock(htmlResponse, http.StatusOK)
 	defer server.Close()
 
-	client, _ := sdk.NewClient(server.URL, "testuser", "testpass", false)
+	client, _ := NewClient(server.URL, "testuser", "testpass", false)
 
 	configs, err := client.GetAllPortVLANConfigs()
 	assert.NoError(t, err)
@@ -280,7 +279,7 @@ func TestGetAllPortVLANConfigs(t *testing.T) {
 	assert.Equal(t, 6, len(configs))
 
 	// Assert the values for each port
-	expectedConfigs := []*sdk.PortVLANConfig{
+	expectedConfigs := []*PortVLANConfig{
 		{Port: 1, PVID: 1, AcceptFrameType: "All"},
 		{Port: 2, PVID: 1, AcceptFrameType: "All"},
 		{Port: 3, PVID: 1, AcceptFrameType: "All"},


### PR DESCRIPTION
also removed the `golangci-lint` log format `github-actions` as it is deprecated